### PR TITLE
Poorman'sindex

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -10,7 +10,7 @@
         <label for="species-input">Species</label> <input type="text" id="species-input"/>
         <script>
             let input = document.getElementById("species-input");
-            let taxomplete = new Taxomplete(input, "https://plazi.factsmission.org/sparql");
+            let taxomplete = new Taxomplete(input);
             taxomplete.action = function(value) {
                 alert(value);
             }

--- a/example/no-indexes.html
+++ b/example/no-indexes.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Taxomplete Example</title>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/awesomplete/1.1.2/awesomplete.css" integrity="sha256-WucYll9Mn2FE68lRHrTpBwzWC+Ra3IeEok0re4TBmgc=" crossorigin="anonymous" />
+        <script src="/taxomplete.js"></script>
+    </head>
+    <body>
+        <label for="species-input">Species</label> <input type="text" id="species-input"/>
+        <script>
+            let input = document.getElementById("species-input");
+            let taxomplete = new Taxomplete(input, "https://lindas-data.ch/sparql");
+            taxomplete.filterPattern = taxomplete.basicFilterPattern;
+            taxomplete.action = function(value) {
+                alert(value);
+            }
+        </script>
+    </body>
+</html>    

--- a/src/taxomplete.js
+++ b/src/taxomplete.js
@@ -11,7 +11,7 @@ export default class Taxomplete {
                 this._sparqlEndpoint = new SparqlEndpoint(sparqlEndpoint);
             }
         } else {
-            this._sparqlEndpoint = new SparqlEndpoint("https://lindas-data.ch/sparql");
+            this._sparqlEndpoint = new SparqlEndpoint("https://treatment.ld.plazi.org/sparql");
         }
         this._input = input;
         let previousValue = input.value;
@@ -100,9 +100,11 @@ export default class Taxomplete {
             let query = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n" +
                     "PREFIX dwc: <http://rs.tdwg.org/dwc/terms/>\n" +
                     "PREFIX dwcfp: <http://filteredpush.org/ontologies/oa/dwcFP#>\n" +
+                    "PREFIX tp: <https://vocab.plazi.org/taxomplete/>\n" +
                     "SELECT DISTINCT ?genus WHERE {\n" +
                     "?sub dwc:genus ?genus .\n" +
                     "?sub rdf:type dwcfp:TaxonName.\n" +
+                    "?sub tp:genusPrefix \"" + prefix.toLowerCase().substr(0,2) + "\".\n" +
                     "FILTER REGEX(?genus, \"^" + prefix + "\",\"i\")\n" +
                     "} ORDER BY UCASE(?genus) LIMIT 10";
             return self._sparqlEndpoint.getSparqlResultSet(query).then(json => {
@@ -114,10 +116,12 @@ export default class Taxomplete {
             let query = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n" +
                     "PREFIX dwc: <http://rs.tdwg.org/dwc/terms/>\n" +
                     "PREFIX dwcfp: <http://filteredpush.org/ontologies/oa/dwcFP#>\n" +
+                    "PREFIX tp: <https://vocab.plazi.org/taxomplete/>\n" +
                     "SELECT DISTINCT ?species WHERE {\n" +
                     "?sub dwc:genus \"" + genus + "\" .\n" +
                     "?sub dwc:species ?species .\n" +
                     "?sub rdf:type dwcfp:TaxonName.\n" +
+                    (prefix.length > 1 ? "?sub tp:speciesPrefix \"" + prefix.toLowerCase().substr(0,2) + "\".\n" : "") +
                     "FILTER REGEX(?species, \"^" + prefix + "\",\"i\")\n" +
                     "} ORDER BY UCASE(?species) LIMIT 10";
             return self._sparqlEndpoint.getSparqlResultSet(query).then(json => {
@@ -129,10 +133,12 @@ export default class Taxomplete {
             let query = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n" +
                     "PREFIX dwc: <http://rs.tdwg.org/dwc/terms/>\n" +
                     "PREFIX dwcfp: <http://filteredpush.org/ontologies/oa/dwcFP#>\n" +
+                    "PREFIX tp: <https://vocab.plazi.org/taxomplete/>\n" +
                     "SELECT DISTINCT ?genus ?species WHERE {\n" +
                     "?sub dwc:genus ?genus .\n" +
                     "?sub dwc:species ?species .\n" +
                     "?sub rdf:type dwcfp:TaxonName.\n" +
+                    (prefix.length > 1 ? "?sub tp:speciesPrefix \"" + prefix.toLowerCase().substr(0,2) + "\".\n" : "") +
                     "FILTER REGEX(?species, \"^" + prefix + "\",\"i\")\n" +
                     "} ORDER BY UCASE(?species) LIMIT 10";
             return self._sparqlEndpoint.getSparqlResultSet(query).then(json => {


### PR DESCRIPTION
Faster lookup without depending on prooprietary sparql extensions.

The following statement must be run on the backend:

```
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX dwc: <http://rs.tdwg.org/dwc/terms/>
PREFIX dwcfp: <http://filteredpush.org/ontologies/oa/dwcFP#>
PREFIX tp: <https://vocab.plazi.org/taxomplete/>
INSERT { GRAPH tp:Index { 
  ?res tp:genusPrefix2 ?prefix
  } } WHERE {
  ?res dwc:genus ?genus .
  ?res rdf:type dwcfp:TaxonName.
  FILTER (strlen(?genus) > 1)
  BIND(LCASE(substr(?genus,1,2)) AS $prefix)
};
INSERT { GRAPH tp:Index { 
  ?res tp:speciesPrefix2 ?prefix
  } } WHERE {
  ?res dwc:species ?species.
  ?res rdf:type dwcfp:TaxonName.
  FILTER (strlen(?species) > 1)
  BIND(LCASE(substr(?species,1,2)) AS $prefix)
};
INSERT { GRAPH tp:Index { 
  ?res tp:genusPrefix3 ?prefix
  } } WHERE {
  ?res dwc:genus ?genus .
  ?res rdf:type dwcfp:TaxonName.
  FILTER (strlen(?genus) > 2)
  BIND(LCASE(substr(?genus,1,3)) AS $prefix)
};
INSERT { GRAPH tp:Index { 
  ?res tp:speciesPrefix3 ?prefix
  } } WHERE {
  ?res dwc:species ?species.
  ?res rdf:type dwcfp:TaxonName.
  FILTER (strlen(?species) > 2)
  BIND(LCASE(substr(?species,1,3)) AS $prefix)
};
INSERT { GRAPH tp:Index { 
  ?res tp:genusPrefix4 ?prefix
  } } WHERE {
  ?res dwc:genus ?genus .
  ?res rdf:type dwcfp:TaxonName.
  FILTER (strlen(?genus) > 3)
  BIND(LCASE(substr(?genus,1,4)) AS $prefix)
};
INSERT { GRAPH tp:Index { 
  ?res tp:speciesPrefix4 ?prefix
  } } WHERE {
  ?res dwc:species ?species.
  ?res rdf:type dwcfp:TaxonName.
  FILTER (strlen(?species) > 3)
  BIND(LCASE(substr(?species,1,4)) AS $prefix)
}
```
to revert back to basic filters without indexes:
```
            let taxomplete = new Taxomplete(input, "https://lindas-data.ch/sparql");
            taxomplete.filterPattern = taxomplete.basicFilterPattern;
```